### PR TITLE
adding nuc_with_data to allow all nuclides

### DIFF
--- a/src/openmc_depletion_plotter/results.py
+++ b/src/openmc_depletion_plotter/results.py
@@ -14,6 +14,12 @@ import plotly.graph_objects as go
 import numpy as np
 import matplotlib.pyplot as plt
 
+lots_of_nuclides = []
+elements = list(openmc.data.ATOMIC_SYMBOL.values())
+for el in elements:
+    for atomic_num in range(1, 1000):
+        lots_of_nuclides.append(f'{el}{atomic_num}')
+
 
 def plot_activity_vs_time(
     self,
@@ -37,7 +43,7 @@ def plot_activity_vs_time(
 
     all_materials = []
     for counter, step in enumerate(time_steps):
-        materials = self.export_to_materials(burnup_index=counter, path=path)[
+        materials = self.export_to_materials(nuc_with_data=lots_of_nuclides,burnup_index=counter, path=path)[
             material_index
         ]
         all_materials.append(materials)
@@ -165,7 +171,7 @@ def plot_atoms_vs_time(
 
     all_materials = []
     for counter, step in enumerate(time_steps):
-        materials = self.export_to_materials(burnup_index=counter, path=path)[
+        materials = self.export_to_materials(nuc_with_data=lots_of_nuclides,burnup_index=counter, path=path)[
             material_index
         ]
         all_materials.append(materials)


### PR DESCRIPTION
Many thanks to a user for reporting and to @eepeterson for identifying the cause of this bug.

details here https://openmc.discourse.group/t/openmc-13-3-depletion-results-is-not-as-expected/2941

This PR is a quick and not very eligant fix that changes the code to call ```export_to_materials``` with the ```nuc_with_data``` argument. This allows nuclides not in the cross_sections.xml to be added to the material when it is exported.