### PR TITLE
added awkward array reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "kaleido",
+    "awkward",
 ]
 dynamic = ["version"]
 

--- a/src/openmc_depletion_plotter/__init__.py
+++ b/src/openmc_depletion_plotter/__init__.py
@@ -29,3 +29,5 @@ from .utils import add_scale_buttons
 from .materials import plot_isotope_chart_of_atoms, plot_isotope_chart_of_activity
 from .integrators import plot_pulse_schedule
 from .results import plot_activity_vs_time, plot_atoms_vs_time, plot_decay_heat_vs_time
+
+from .core import read_depletion_results

--- a/src/openmc_depletion_plotter/core.py
+++ b/src/openmc_depletion_plotter/core.py
@@ -1,0 +1,67 @@
+import h5py
+import awkward as ak
+import numpy as np
+from pathlib import Path
+
+
+def read_depletion_results(filename: str | Path = 'depletion_results.h5') -> ak.Array:
+    """
+    Reads depletion results from an OpenMC depletion_results.h5 HDF5 file and
+    returns a memory efficient awkward array of atom quantities.
+
+    Args:
+        filename: Path to the HDF5 file containing depletion results.
+
+    Returns:
+        awkward.Array: An awkward array containing atom quantities for each timestep.
+            - "timestep" (float): The end time of the timestep in seconds.
+            - "material_id" (int): The ID of the material.
+            - "nuclide" (str): The name of the nuclide.
+            - "atoms" (float): The quantity of the nuclides in the material at that timestep in atoms.
+    """
+
+    all_atom_quantities = ak.Array([])
+
+    with h5py.File(str(filename), "r") as handle:
+
+        mat_id_map = {}
+        nuclide_map = {}
+
+        for mat, mat_handle in handle["/materials"].items():
+            vol = mat_handle.attrs["volume"]
+            ind = mat_handle.attrs["index"]
+
+            mat_id_map[int(ind)] = int(mat)
+
+        for nuc, nuc_handle in handle["/nuclides"].items():
+            ind_atom = nuc_handle.attrs["atom number index"]
+            nuclide_map[int(ind_atom)] = nuc
+
+        # Get number of results stored
+        n = handle["number"][...].shape[0]
+
+        for step in range(n):
+
+            number_dset = handle["/number"]
+            data = number_dset[step, :, :, :]
+
+            timestep_data = data[0, :, :]
+            materials, nuclides = np.nonzero(timestep_data)
+            atoms = timestep_data[materials, nuclides]
+            # time returns a tuple with start and end time, end time is the one which corresponds to the atoms
+
+            timestep_awk = ak.Array(
+                [
+                    {
+                        "timestep": step,
+                        "material_id": int(mat_id_map[m]),
+                        "nuclide": nuclide_map[n],
+                        "atoms": a,
+                    }
+                    for m, n, a in zip(materials, nuclides, atoms)
+                ]
+            )
+
+            all_atom_quantities = ak.concatenate([all_atom_quantities, timestep_awk])
+
+    return all_atom_quantities

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,25 @@
+import openmc_depletion_plotter
+
+
+def test_read_depletion_results():
+    results = openmc_depletion_plotter.read_depletion_results('tests/depletion_results.h5')
+    assert len(results) == 25
+
+    # this is the unirradiated material so it should return just Fe56
+    condition = results["timestep"] == 0
+    filter_data = results[condition][["material_id", "timestep", "nuclide", "atoms"]]
+    assert len(filter_data)  == 1
+    assert filter_data[0].timestep == 0
+    assert filter_data[0].nuclide == 'Fe56'
+    assert filter_data[0].atoms == 4.7307702602013954e29
+    assert filter_data[0].material_id == 1
+
+    # filter should return lots of results as this is just after irradiation
+    condition = results["timestep"] == 3
+    filter_data = results[condition][["material_id", "timestep", "nuclide", "atoms"]]
+    assert len(filter_data) > 1
+
+    # filter should return no matching results as there are only 3 timesteps
+    condition = results["timestep"] == 4
+    filter_data = results[condition][["material_id", "timestep", "nuclide", "atoms"]]
+    assert len(filter_data) == 0


### PR DESCRIPTION
I am adding this method of reading in the depletion results into a awkward array

this takes considerably less memory than the numpy based method currently used in openmc as that must contain an etry for every nuclide present at all timesteps and all materials.

this typically results in a large array of 0 values with a minority of non zero values.

the awkward array allows the data to be stored without using blank 0 values while still allowing nice filtering like pandas or numpy

I think this sort of memory efficient reading will be useful when we have large mesh tallies with material data for millions of mesh elements.  

example filtering and plotting of an awkward array
```python
condition = (
    (awkward_array["material_id"] == 1) &
    (awkward_array["nuclide"] == 'Co60') &
    (awkward_array["atoms"] > 1e13)  # filter out small quantities
)
filter_data=awkward_array[condition][["timestep", "nuclide", "atoms"]]

y_values = [entry['atoms'] for entry in filter_data]
x_values = [entry['timestep'] for entry in filter_data]

plt.plot(x_values, y_values)

plt.xlabel('Time (s)')
plt.ylabel('Number of atoms')
plt.title(f'Number of unstable atoms in material')
plt.legend()
plt.savefig(f'atoms_quantity_mat_{material_id}.png')
```
 